### PR TITLE
main

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,9 @@ for c, linha in zip(range(0, len(script)), script):
     elif linha.split(' ')[0] == 'deletar':
         linha = linha.split(' ')
         monarca.variavel('del', linha[2])
-    elif linha.split(' ')[0] == 'mostrar':
+    elif linha[:16] == 'mostrar na tela:':
         monarca.escrever(linha)
+    else:
+        monarca.erro('Comando não identificado.')
     # Vou adicionar mais depois, implementar as outras funções.
     #testar delete que ta na documentação


### PR DESCRIPTION
Ao digitar um comando errado, o Monarca só ignora e continua na próxima linha, sem nenhum tipo de erro. Para resolver, foi adicionado um else no final do código.

Além disso, fiz uma edição na identificação do comando "mostrar na tela". Ao invés de identificar só "mostrar", usei slicing para identificar o comando inteiro. Isso deixa o código inconsistente ao não usar split como nos outros comandos, mas evita que o usuário escreva "mostrar gsogsajsfoiafcavalosgiorjegoivinodiweorug tela:" e o código ainda funcione. 
Isso também evita outro problema, que deve ser resolvido mesmo se essa minha alteração não for aceita: Ao errar na digitação de "tela:", o Monarca dá um erro de Python. Isso se deve à função escrever() que procura na linha o texto "tela:". A minha solução resolve esse problema também porque já se certifica que esse trecho esteja escrito corretamente.